### PR TITLE
Fix: Gemfile.lockを修正 #9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -222,6 +224,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   better_errors


### PR DESCRIPTION
## 概要
`Failed to install gems via Bundler.`というエラーが発生。
原因は、herokuのbundlerとローカルでのbundlerのバージョンに相違があることらしい。

エラー文にあった`bundle lock --add-platform x86_64-linux`を実行。