### PR TITLE
Fix: お気に入りリストのスタイルを修正 #66

### DIFF
--- a/frontend/src/components/organisms/FavoritesMenu.tsx
+++ b/frontend/src/components/organisms/FavoritesMenu.tsx
@@ -45,27 +45,40 @@ export const FavoritesMenu: VFC<Props> = memo((props) => {
       })
   }
 
+  const menuItem = () => {
+    if (favoriteFoods) {
+      return (
+        favoriteFoods.map(favoriteFood => (
+          <Flex key={ favoriteFood.id }>
+            <MenuItem
+              w='80%'
+              ml={1}
+              className='favorite'
+              onClick={ () => onClickFavorite(favoriteFood) }
+            >
+              { favoriteFood.name }
+            </MenuItem>
+            <MenuItem  w='15%' className='favorite'>
+              <SmallCloseIcon color='gray' onClick={ () => onClickDeleteFavorite(favoriteFood)} />
+            </MenuItem>
+          </Flex>
+        ))
+      )
+    } else {
+      return (
+        <MenuItem ml={1} className='favorite'>登録されていません</MenuItem>
+      )
+    }
+  }
+
   return (
     <Menu autoSelect={false}>
-      <MenuButton style={{ background: 'white' }}>
+      <MenuButton>
         <HamburgerIcon />
       </MenuButton>
-      <MenuList>
+      <MenuList maxW='200px'>
         <MenuGroup title='お気に入りから記録する'>
-          { 
-            favoriteFoods.length === 0
-            ? <MenuItem ml={1} _hover={{ bg: 'white' }}>登録されていません</MenuItem>
-            : favoriteFoods.map(favoriteFood => (
-                <Flex key={ favoriteFood.id }>
-                  <MenuItem w='80%' ml={1} onClick={ () => onClickFavorite(favoriteFood) } _hover={{ bg: 'white' }}>
-                    { favoriteFood.name }
-                  </MenuItem>
-                  <MenuItem _hover={{ bg: 'white', cursor: 'pointer' }}>
-                    <SmallCloseIcon color='gray' onClick={ () => onClickDeleteFavorite(favoriteFood)} />
-                  </MenuItem>
-                </Flex>
-              )) 
-          }
+          { menuItem() }
         </MenuGroup>
       </MenuList>
     </Menu>

--- a/frontend/src/components/organisms/FoodDetailModal.tsx
+++ b/frontend/src/components/organisms/FoodDetailModal.tsx
@@ -78,7 +78,7 @@ export const FoodDetailModal: VFC<Props> = memo((props) => {
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} autoFocus={false} size='full'>
+    <Modal isOpen={isOpen} onClose={onClose} autoFocus={false} size='sm'>
       <ModalOverlay />
       <ModalContent bg={ bgColor({ food: { price: foodPrice || 0 }, basePrice: 100 }) }>
         <ModalHeader textAlign='center'>

--- a/frontend/src/components/pages/New.tsx
+++ b/frontend/src/components/pages/New.tsx
@@ -79,7 +79,7 @@ export const New: VFC = memo(() => {
 
   // カレンダーへ移動する
   const navigate = useNavigate()
-  const onClickShowCalendar = useCallback(() => navigate('/calendar'), [navigate])
+  const onClickShowCalendar = useCallback(() => navigate('/'), [navigate])
 
   return (
     <Flex align='center' justify='center' height='100vh'>

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -122,3 +122,17 @@ body {
   cursor: pointer;
   padding: 8px 16px;
 }
+
+// お気に入りリスト
+.favorite {
+  background: #fff !important;
+
+  &hover {
+    background: #fff !important;
+  }
+}
+
+// inputの円とkcal
+.css-17kf94w, .css-ur97uj {
+  z-index: 1 !important;
+}


### PR DESCRIPTION
## 概要

以下を修正。

- お気に入りリストが金額、カロリーのinputの円、カロリーと重ならないように修正
- お気に入りの名前が長いとき、リストの幅が長くなりすぎないように修正
- Foodの詳細モーダルのサイズを小さくするように修正
- カレンダーへのリンクのpathが`/calendar`のままだったので`/`に修正