### PR TITLE
Fix: 力画面の名前のinputにグレーの線が出ないように修正 #68

### DIFF
--- a/frontend/src/components/organisms/FavoritesMenu.tsx
+++ b/frontend/src/components/organisms/FavoritesMenu.tsx
@@ -46,7 +46,7 @@ export const FavoritesMenu: VFC<Props> = memo((props) => {
   }
 
   const menuItem = () => {
-    if (favoriteFoods) {
+    if (favoriteFoods.length) {
       return (
         favoriteFoods.map(favoriteFood => (
           <Flex key={ favoriteFood.id }>

--- a/frontend/src/components/pages/Calendar.tsx
+++ b/frontend/src/components/pages/Calendar.tsx
@@ -45,7 +45,7 @@ export const Calendar: VFC = memo(() => {
         dayjs(food.created_at).format('YYYY-MM-DD') === dayjs(arg.event.startStr).format('YYYY-MM-DD')
       ))
     )
-    setClickDay(dayjs(foods[0].created_at).format('D'))
+    setClickDay(dayjs(arg.event.startStr).format('D'))
     onOpen()
   }, [onOpen, foods])
 

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -91,12 +91,12 @@ body {
 // サジェスト機能
 .react-autosuggest__container {
   position: relative;
+  border: 1px solid #E2E8F0;
+  border-radius: 4px;
 }
 
 .react-autosuggest__input {
   padding: 8px 16px;
-  border: 1px solid #E2E8F0;
-  border-radius: 4px;
 }
 
 .react-autosuggest__input--focused {


### PR DESCRIPTION
## 概要

以下を修正。

- 入力画面の名前のinputにグレーの線が出ないように修正
- カレンダーの`event`をクリックしたときにドロワーに正しい日付が表示されるように修正
- お気に入り登録が0の場合はお気に入り登録されていませんと表示されるように修正